### PR TITLE
Add renditions cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fix: Update Wagtail to 2.11
 - Fix: Update Django to 3.1.2
 - Fix: Update DRF
+- Fix: Replace Boto with Boto3 (Martin Lindvall)
 
 
 ## 7.0. (XXX.XX.XX) - SKIPPED

--- a/{{cookiecutter.project_name}}/src/pipit/settings/prod.py
+++ b/{{cookiecutter.project_name}}/src/pipit/settings/prod.py
@@ -16,7 +16,15 @@ CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.db.DatabaseCache",
         "LOCATION": "cache_table",
-    }
+    },
+    "renditions": {
+        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
+        "LOCATION": "cache_table_rendition",
+        "TIMEOUT": 600,
+        "OPTIONS": {
+            "MAX_ENTRIES": 1000,
+        }
+    },
 }
 
 STATICFILES_STORAGE = (

--- a/{{cookiecutter.project_name}}/src/pipit/settings/stage.py
+++ b/{{cookiecutter.project_name}}/src/pipit/settings/stage.py
@@ -16,7 +16,15 @@ CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.db.DatabaseCache",
         "LOCATION": "cache_table",
-    }
+    },
+    "renditions": {
+        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
+        "LOCATION": "cache_table_rendition",
+        "TIMEOUT": 600,
+        "OPTIONS": {
+            "MAX_ENTRIES": 1000,
+        }
+    },
 }
 
 STATICFILES_STORAGE = (


### PR DESCRIPTION
This PR adds cache by default for image renditions and originates from a discussion me and @saraojelind had regarding common application bottlenecks.

What do you think, a good improvement or perhaps unnecessary or even something that clutters the boilerplate? 

(The PR fails due to a unrelated issue with the latest Boto -> Boto3. I will fix it in devlop.)