### PR TITLE
Implement App Router

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,16 @@
 name: Test cookiecutter scaffolder
 on: [push, pull_request]
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        experimental_use_app_router: [
+          {name: "Page router", value: "False"},
+          {name: "App router", value: "True"},
+        ]
+    name: Test ${{ matrix.experimental_use_app_router.name }}
     steps:
       - uses: actions/checkout@v4
       - uses: "actions/setup-python@v4"
@@ -12,29 +20,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install cookiecutter
-      - name: Run cookiecutter
+      - name: Cleanup
         run: |
           set -x
           rm -rf Company-Project
-          cookiecutter . --no-input
-      - name: Archive generated-project
-        uses: actions/upload-artifact@v3
-        with:
-          name: generated-project
-          path: ./Company-Project
-          retention-days: 1
-
-  backend:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - run: rm -rf Company-Project
-      - name: Restore generated-project
-        uses: actions/download-artifact@v3
-        with:
-          name: generated-project
-          path: Company-Project
+      - name: Run cookiecutter
+        run: |
+          cookiecutter . --no-input experimental_use_app_router=${{ matrix.experimental_use_app_router.value }}
       - name: Create docker-compose config for running boilerplate tests
         run: |
           cp docker-compose-circleci.yml Company-Project/docker-compose-circleci.yml
@@ -54,21 +46,6 @@ jobs:
           docker-compose -f docker-compose-circleci.yml run --rm python test
           docker-compose -f docker-compose-circleci.yml run --rm python typecheck
           docker-compose -f docker-compose-circleci.yml run --rm python lint
-
-  frontend:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: "actions/setup-node@v4"
-        with:
-          node-version: "20"
-      - run: rm -rf Company-Project
-      - name: Restore generated-project
-        uses: actions/download-artifact@v3
-        with:
-          name: generated-project
-          path: Company-Project
       - name: Run frontend tests
         run: |
           cd Company-Project/frontend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Add experimental app router support (@marteinn)
+
 ### Changed
 - Return seo robots as struct to prepare for Next.js metadata api (@marteinn)
 - Pass host as query param as Next.js will drop header in app router (@marteinn)

--- a/Company-Project/frontend/api/wagtail.js
+++ b/Company-Project/frontend/api/wagtail.js
@@ -82,7 +82,25 @@ export async function getRequest(url, params, options) {
         ...headers,
     };
     const queryString = querystring.stringify(params);
-    const res = await fetch(`${url}?${queryString}`, { headers });
+
+    let fetchOptions = { headers };
+
+    if (options?.cache) {
+        fetchOptions = {
+            ...fetchOptions,
+            cache: options.cache,
+        };
+    }
+
+    if (options?.revalidate) {
+        fetchOptions = {
+            ...fetchOptions,
+            next: {
+                revalidate: options.revalidate,
+            },
+        };
+    }
+    const res = await fetch(`${url}?${queryString}`, fetchOptions);
 
     if (res.status < 200 || res.status >= 300) {
         const error = new WagtailApiResponseError(res, url, params);

--- a/Company-Project/frontend/containers/BasePage/BasePage.js
+++ b/Company-Project/frontend/containers/BasePage/BasePage.js
@@ -5,7 +5,7 @@ import dynamic from 'next/dynamic';
 
 const WagtailUserbar = dynamic(() => import('../../components/WagtailUserbar'));
 
-const BasePage = ({ children, seo, wagtailUserbar }) => {
+const BasePage = ({ children, seo, shouldRenderSeo, wagtailUserbar }) => {
     const {
         seoHtmlTitle,
         seoMetaDescription,
@@ -23,46 +23,58 @@ const BasePage = ({ children, seo, wagtailUserbar }) => {
     } = seo;
     return (
         <>
-            <Head>
-                <title>{seoHtmlTitle}</title>
-                <link rel="icon" href="/favicon.ico" />
-                {!!seoMetaDescription && (
-                    <meta name="description" content={seoMetaDescription} />
-                )}
-                {!!seoOgTitle && (
-                    <meta property="og:title" content={seoOgTitle} />
-                )}
-                {!!seoOgDescription && (
-                    <meta
-                        property="og:description"
-                        content={seoOgDescription}
-                    />
-                )}
-                {!!seoOgUrl && <meta property="og:url" content={seoOgUrl} />}
-                {!!seoOgImage && (
-                    <meta property="og:image" content={seoOgImage} />
-                )}
-                {!!seoOgType && <meta property="og:type" content={seoOgType} />}
-                {!!seoTwitterTitle && (
-                    <meta property="twitter:title" content={seoTwitterTitle} />
-                )}
-                {!!seoTwitterDescription && (
-                    <meta
-                        property="twitter:description"
-                        content={seoTwitterDescription}
-                    />
-                )}
-                {!!seoTwitterUrl && (
-                    <meta property="twitter:url" content={seoTwitterUrl} />
-                )}
-                {!!seoTwitterImage && (
-                    <meta property="twitter:image" content={seoTwitterImage} />
-                )}
-                <meta name="robots" content={seoMetaRobots.value} />
-                {!!canonicalLink && (
-                    <link rel="canonical" href={canonicalLink} />
-                )}
-            </Head>
+            {shouldRenderSeo && (
+                <Head>
+                    <title>{seoHtmlTitle}</title>
+                    <link rel="icon" href="/favicon.ico" />
+                    {!!seoMetaDescription && (
+                        <meta name="description" content={seoMetaDescription} />
+                    )}
+                    {!!seoOgTitle && (
+                        <meta property="og:title" content={seoOgTitle} />
+                    )}
+                    {!!seoOgDescription && (
+                        <meta
+                            property="og:description"
+                            content={seoOgDescription}
+                        />
+                    )}
+                    {!!seoOgUrl && (
+                        <meta property="og:url" content={seoOgUrl} />
+                    )}
+                    {!!seoOgImage && (
+                        <meta property="og:image" content={seoOgImage} />
+                    )}
+                    {!!seoOgType && (
+                        <meta property="og:type" content={seoOgType} />
+                    )}
+                    {!!seoTwitterTitle && (
+                        <meta
+                            property="twitter:title"
+                            content={seoTwitterTitle}
+                        />
+                    )}
+                    {!!seoTwitterDescription && (
+                        <meta
+                            property="twitter:description"
+                            content={seoTwitterDescription}
+                        />
+                    )}
+                    {!!seoTwitterUrl && (
+                        <meta property="twitter:url" content={seoTwitterUrl} />
+                    )}
+                    {!!seoTwitterImage && (
+                        <meta
+                            property="twitter:image"
+                            content={seoTwitterImage}
+                        />
+                    )}
+                    <meta name="robots" content={seoMetaRobots.value} />
+                    {!!canonicalLink && (
+                        <link rel="canonical" href={canonicalLink} />
+                    )}
+                </Head>
+            )}
             <div className="BasePage">{children}</div>
             {!!wagtailUserbar && <WagtailUserbar {...wagtailUserbar} />}
         </>
@@ -71,6 +83,7 @@ const BasePage = ({ children, seo, wagtailUserbar }) => {
 
 BasePage.defaultProps = {
     seo: {},
+    shouldRenderSeo: true,
 };
 
 BasePage.propTypes = {
@@ -88,6 +101,7 @@ BasePage.propTypes = {
             value: PropTypes.string,
         }),
     }),
+    shouldRenderSeo: PropTypes.bool,
     wagtailUserbar: PropTypes.shape({
         html: PropTypes.string,
     }),

--- a/Company-Project/frontend/containers/NotFoundPage/NotFoundPage.js
+++ b/Company-Project/frontend/containers/NotFoundPage/NotFoundPage.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import s from './NotFoundPage.module.css';
 
-const NotFoundPage = () => {
-    return <div className={s.Container}>NotFoundPage</div>;
+const NotFoundPage = ({ exception }) => {
+    return <div className={s.Container}>{exception}</div>;
 };
 
 NotFoundPage.propTypes = {};
-
-NotFoundPage.defaultProps = {};
 
 export default NotFoundPage;

--- a/Company-Project/frontend/containers/PasswordProtectedPage/PasswordProtectedPage.js
+++ b/Company-Project/frontend/containers/PasswordProtectedPage/PasswordProtectedPage.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/Company-Project/frontend/middleware.js
+++ b/Company-Project/frontend/middleware.js
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+
+export function middleware(request) {
+    const url = new URL(request.url);
+    const origin = url.origin;
+    const pathname = url.pathname;
+    const requestHeaders = new Headers(request.headers);
+
+    requestHeaders.set('x-url', request.url);
+    requestHeaders.set('x-origin', origin);
+    requestHeaders.set('x-pathname', pathname);
+
+    return NextResponse.next({
+        request: {
+            headers: requestHeaders,
+        },
+    });
+}

--- a/Company-Project/frontend/package.json
+++ b/Company-Project/frontend/package.json
@@ -24,18 +24,6 @@
         "react": "^18.2.0",
         "react-dom": "18.2.0"
     },
-    "browserslist": {
-        "production": [
-            ">0.2%",
-            "not dead",
-            "not op_mini all"
-        ],
-        "development": [
-            "last 1 chrome version",
-            "last 1 firefox version",
-            "last 1 safari version"
-        ]
-    },
     "husky": {
         "hooks": {
             "pre-commit": "pretty-quick --staged --pattern 'frontend/**' && jest --onlyChanged",

--- a/Company-Project/src/pipit/urls.py
+++ b/Company-Project/src/pipit/urls.py
@@ -54,7 +54,6 @@ def trigger_error(request):
 
 def health_check(request):
     from django.http import HttpResponse
-
     return HttpResponse("Its alive")
 
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -15,12 +15,14 @@
     "docker_vscode_debug_port": 5678,
     "version": "0.1.0",
     "software_license": ["proprietary", "MIT"],
+    "experimental_use_app_router": false,
     "_copy_without_render": [
         "*.git",
         "frontend/cli",
         "frontend/.next",
         "frontend/components",
         "frontend/containers",
-        "frontend/pages"
+        "frontend/pages",
+        "frontend/app"
     ]
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,8 +1,8 @@
 import os
-import stat
 import shutil
-import subprocess
 
+
+EXPERIMENTAL_USE_APP_ROUTER = '{{ cookiecutter.experimental_use_app_router }}' == 'True'
 
 PROJECT_DIRECTORY = os.path.realpath(os.path.curdir)
 DOCKER_DIR = os.path.join(PROJECT_DIRECTORY, 'docker', 'config')
@@ -11,3 +11,8 @@ shutil.copyfile(
     os.path.join(DOCKER_DIR, 'python.example.env'),
     os.path.join(DOCKER_DIR, 'python.env')
 )
+
+if EXPERIMENTAL_USE_APP_ROUTER:
+    shutil.rmtree(os.path.join(PROJECT_DIRECTORY, 'frontend', 'pages'))
+else:
+    shutil.rmtree(os.path.join(PROJECT_DIRECTORY, 'frontend', 'app'))

--- a/{{cookiecutter.project_name}}/frontend/.env
+++ b/{{cookiecutter.project_name}}/frontend/.env
@@ -1,2 +1,2 @@
-WAGTAIL_API_URL=http://localhost:{{cookiecutter.docker_web_port}}/wt/api/nextjs
+WAGTAIL_API_URL=http://localhost:8081/wt/api/nextjs
 NEXT_PUBLIC_WAGTAIL_API_URL=/wt/api/nextjs

--- a/{{cookiecutter.project_name}}/frontend/api/wagtail.js
+++ b/{{cookiecutter.project_name}}/frontend/api/wagtail.js
@@ -82,7 +82,25 @@ export async function getRequest(url, params, options) {
         ...headers,
     };
     const queryString = querystring.stringify(params);
-    const res = await fetch(`${url}?${queryString}`, { headers });
+
+    let fetchOptions = { headers };
+
+    if (options?.cache) {
+        fetchOptions = {
+            ...fetchOptions,
+            cache: options.cache,
+        };
+    }
+
+    if (options?.revalidate) {
+        fetchOptions = {
+            ...fetchOptions,
+            next: {
+                revalidate: options.revalidate,
+            },
+        };
+    }
+    const res = await fetch(`${url}?${queryString}`, fetchOptions);
 
     if (res.status < 200 || res.status >= 300) {
         const error = new WagtailApiResponseError(res, url, params);

--- a/{{cookiecutter.project_name}}/frontend/app/[...path]/page.js
+++ b/{{cookiecutter.project_name}}/frontend/app/[...path]/page.js
@@ -1,0 +1,3 @@
+import CatchAllPage from '../page';
+
+export default CatchAllPage;

--- a/{{cookiecutter.project_name}}/frontend/app/_draft.js
+++ b/{{cookiecutter.project_name}}/frontend/app/_draft.js
@@ -1,0 +1,3 @@
+import CatchAllPage from '../page';
+
+export default CatchAllPage;

--- a/{{cookiecutter.project_name}}/frontend/app/api/draft/route.js
+++ b/{{cookiecutter.project_name}}/frontend/app/api/draft/route.js
@@ -1,0 +1,27 @@
+import { draftMode } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { headers } from 'next/headers';
+
+export async function GET(request) {
+    const { searchParams } = new URL(request.url);
+
+    const contentType = searchParams.get('content_type');
+    const token = searchParams.get('token');
+    const host = searchParams.get('host');
+
+    if (!contentType || !token) {
+        return res
+            .status(401)
+            .json({ message: 'Missing contentType and/or token' });
+    }
+
+    const headersList = headers();
+    const referer = headersList.get('referer') || '';
+    const inPreviewPanel = referer.includes('in_preview_panel=true');
+
+    draftMode().enable();
+
+    redirect(
+        `/_draft?contentType=${contentType}&token=${token}&inPreviewPanel=${inPreviewPanel ? 'true' : 'false'}`
+    );
+}

--- a/{{cookiecutter.project_name}}/frontend/app/clientcomponent.js
+++ b/{{cookiecutter.project_name}}/frontend/app/clientcomponent.js
@@ -1,0 +1,15 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const ClientComponent = ({ setCookieHeader }) => {
+    'use client';
+
+    useEffect(() => {
+        document.cookie = setCookieHeader;
+    }, [setCookieHeader]);
+
+    return null;
+};
+
+export default ClientComponent;

--- a/{{cookiecutter.project_name}}/frontend/app/layout.js
+++ b/{{cookiecutter.project_name}}/frontend/app/layout.js
@@ -1,0 +1,27 @@
+import { Inter } from 'next/font/google';
+import { headers, draftMode } from 'next/headers';
+import {
+    getPage,
+    getPagePreview,
+    getRedirect,
+    getAllPages,
+    WagtailApiResponseError,
+} from '../api/wagtail';
+import '../index.css';
+// import './globals.css'
+
+const inter = Inter({ subsets: ['latin'] });
+
+export default async function RootLayout({ children, ...props }) {
+    const pathname = headers().get('x-pathname') || '';
+    // const data = await getPage({
+    //     path: pathname,
+    //     searchParams: {},
+    // })
+
+    return (
+        <html lang="en">
+            <body className={inter.className}>{children}</body>
+        </html>
+    );
+}

--- a/{{cookiecutter.project_name}}/frontend/app/not-found.js
+++ b/{{cookiecutter.project_name}}/frontend/app/not-found.js
@@ -1,0 +1,30 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { getViewData, getPublicViewData } from '../api/wagtail';
+import LazyContainers from '../containers/LazyContainers';
+
+export default function DynamicNotFoundPage() {
+    const [data, setData] = useState(null);
+    useEffect(() => {
+        async function fetchData() {
+            const { json: pageData } = await getPublicViewData('404');
+            setData(pageData);
+        }
+        fetchData();
+    }, []);
+
+    if (!data) {
+        return null;
+    }
+
+    return <NotFoundPage {...data} />;
+}
+
+function NotFoundPage({ componentName, componentProps }) {
+    const Component = LazyContainers[componentName];
+    if (!Component) {
+        return <h1>Component {componentName} not found</h1>;
+    }
+    return <Component {...componentProps} />;
+}

--- a/{{cookiecutter.project_name}}/frontend/app/page.js
+++ b/{{cookiecutter.project_name}}/frontend/app/page.js
@@ -1,0 +1,271 @@
+import Image from 'next/image';
+import { headers, draftMode } from 'next/headers';
+import { unstable_cache } from 'next/cache';
+import { cache } from 'react';
+import { notFound, permanentRedirect, redirect } from 'next/navigation';
+import LazyContainers from '../containers/LazyContainers';
+
+import {
+    getPage,
+    getPagePreview,
+    getRedirect,
+    getAllPages,
+    WagtailApiResponseError,
+} from '../api/wagtail';
+import ClientComponent from './clientcomponent';
+
+const isProd = process.env.NODE_ENV === 'production';
+
+async function getPreviewPageData({
+    contentType,
+    token,
+    inPreviewPanel,
+    headers = {},
+}) {
+    try {
+        const { json: pagePreviewData } = await getPagePreview(
+            contentType,
+            token,
+            {
+                in_preview_panel: inPreviewPanel,
+            },
+            {
+                headers,
+            }
+        );
+        return {
+            props: pagePreviewData,
+        };
+    } catch (err) {
+        if (!(err instanceof WagtailApiResponseError)) {
+            throw err;
+        }
+
+        if (!isProd && err.response.status >= 500) {
+            const html = await err.response.text();
+            return {
+                props: {
+                    componentName: 'PureHtmlPage',
+                    componentProps: { html },
+                },
+            };
+        }
+
+        throw err;
+    }
+
+    return { notFound: true };
+}
+
+async function getPageData({
+    path,
+    searchParams,
+    headers = {},
+    options = null,
+}) {
+    // Try to serve page
+    try {
+        const {
+            json: { componentName, componentProps, redirect, customResponse },
+            headers: responseHeaders,
+        } = await getPage(path, searchParams, {
+            headers,
+            cache: options?.cache,
+            revalidate: options?.revalidate,
+        });
+
+        let setCookieHeader = null;
+        if (responseHeaders.get('set-cookie')) {
+            setCookieHeader = responseHeaders.get('set-cookie');
+        }
+
+        /*
+        if (customResponse) {
+            const { body, body64, contentType } = customResponse;
+            res.setHeader('Content-Type', contentType);
+            res.statusCode = 200;
+            res.write(body64 ? Buffer.from(body64, 'base64') : body);
+            res.end();
+
+            return { props: {} };
+        }
+        */
+
+        if (redirect) {
+            const { destination, isPermanent } = redirect;
+            return {
+                redirect: {
+                    destination: destination,
+                    permanent: isPermanent,
+                },
+            };
+        }
+
+        return {
+            props: { componentName, componentProps },
+            setCookieHeader,
+        };
+    } catch (err) {
+        if (!(err instanceof WagtailApiResponseError)) {
+            throw err;
+        }
+
+        // When in development, show django error page on error
+        if (!isProd && err.response.status >= 500) {
+            const html = await err.response.text();
+            return {
+                props: {
+                    componentName: 'PureHtmlPage',
+                    componentProps: { html },
+                },
+            };
+        }
+
+        if (err.response.status >= 500) {
+            throw err;
+        }
+    }
+
+    // Try to serve redirect
+    try {
+        const { json: redirect } = await getRedirect(path, searchParams, {
+            headers,
+        });
+
+        const { destination, isPermanent } = redirect;
+        return {
+            redirect: {
+                destination: destination,
+                permanent: isPermanent,
+            },
+        };
+    } catch (err) {
+        if (!(err instanceof WagtailApiResponseError)) {
+            throw err;
+        }
+
+        if (err.response.status >= 500) {
+            throw err;
+        }
+    }
+
+    return { notFound: true };
+}
+
+export async function generateMetadata({ params, searchParams }, parent) {
+    const headersList = headers();
+    const data = await getPageData({
+        path: params.path,
+        searchParams: {
+            host: headersList.get('host'),
+        },
+        options: {
+            //cache: 'force-cache',
+            revalidate: 900, // 15 minutes
+        },
+    });
+
+    if (data?.redirect) {
+        return {};
+    }
+
+    const { seo } = data.props.componentProps;
+
+    const {
+        seoHtmlTitle,
+        seoMetaDescription,
+        seoOgTitle,
+        seoOgDescription,
+        seoOgUrl,
+        seoOgImage,
+        seoOgType,
+        seoTwitterTitle,
+        seoTwitterDescription,
+        seoTwitterUrl,
+        seoTwitterImage,
+        seoMetaRobots,
+        canonicalLink,
+    } = seo;
+
+    return {
+        metadataBase: new URL(seoOgUrl),
+        title: seoHtmlTitle,
+        description: seoMetaDescription,
+        openGraph: {
+            title: seoOgTitle,
+            description: seoOgDescription,
+            images: seoOgImage,
+            url: seoOgUrl,
+            type: seoOgType || 'website',
+        },
+        twitter: {
+            title: seoTwitterTitle,
+            description: seoTwitterDescription,
+            images: [seoTwitterImage],
+        },
+        alternates: {
+            canonical: canonicalLink,
+        },
+        robots: {
+            index: seoMetaRobots.index,
+            follow: seoMetaRobots.follow,
+        },
+    };
+}
+
+export default async function CatchAllPage(props) {
+    const headersList = headers();
+    const { params, searchParams } = props;
+    const { isEnabled: isDraftEnabled } = draftMode();
+
+    let data = null;
+    if (isDraftEnabled && searchParams.contentType && searchParams.token) {
+        const { contentType, token, inPreviewPanel } = searchParams;
+        data = await getPreviewPageData({
+            contentType,
+            token,
+            inPreviewPanel: inPreviewPanel === 'true',
+            headers: {
+                cookie: headersList.get('cookie'),
+            },
+        });
+    } else {
+        data = await getPageData({
+            path: params.path,
+            searchParams: {
+                ...searchParams,
+                host: headersList.get('host'),
+            },
+            headers: {
+                cookie: headersList.get('cookie'),
+            },
+        });
+    }
+
+    if (data?.redirect) {
+        const { destination, permanent } = data.redirect;
+        return permanent
+            ? permanentRedirect(destination)
+            : redirect(destination);
+    }
+
+    if (data.notFound) {
+        return notFound();
+    }
+
+    const { componentName, componentProps } = data.props || {};
+    const setCookieHeader = data.setCookieHeader;
+
+    const Component = LazyContainers[componentName];
+    if (!Component) {
+        return <h1>Component {componentName} not found</h1>;
+    }
+    return (
+        <>
+            {!!setCookieHeader && (
+                <ClientComponent setCookieHeader={setCookieHeader} />
+            )}
+            <Component {...componentProps} shouldRenderSeo={false} />
+        </>
+    );
+}

--- a/{{cookiecutter.project_name}}/frontend/containers/BasePage/BasePage.js
+++ b/{{cookiecutter.project_name}}/frontend/containers/BasePage/BasePage.js
@@ -5,7 +5,7 @@ import dynamic from 'next/dynamic';
 
 const WagtailUserbar = dynamic(() => import('../../components/WagtailUserbar'));
 
-const BasePage = ({ children, seo, wagtailUserbar }) => {
+const BasePage = ({ children, seo, shouldRenderSeo, wagtailUserbar }) => {
     const {
         seoHtmlTitle,
         seoMetaDescription,
@@ -23,46 +23,58 @@ const BasePage = ({ children, seo, wagtailUserbar }) => {
     } = seo;
     return (
         <>
-            <Head>
-                <title>{seoHtmlTitle}</title>
-                <link rel="icon" href="/favicon.ico" />
-                {!!seoMetaDescription && (
-                    <meta name="description" content={seoMetaDescription} />
-                )}
-                {!!seoOgTitle && (
-                    <meta property="og:title" content={seoOgTitle} />
-                )}
-                {!!seoOgDescription && (
-                    <meta
-                        property="og:description"
-                        content={seoOgDescription}
-                    />
-                )}
-                {!!seoOgUrl && <meta property="og:url" content={seoOgUrl} />}
-                {!!seoOgImage && (
-                    <meta property="og:image" content={seoOgImage} />
-                )}
-                {!!seoOgType && <meta property="og:type" content={seoOgType} />}
-                {!!seoTwitterTitle && (
-                    <meta property="twitter:title" content={seoTwitterTitle} />
-                )}
-                {!!seoTwitterDescription && (
-                    <meta
-                        property="twitter:description"
-                        content={seoTwitterDescription}
-                    />
-                )}
-                {!!seoTwitterUrl && (
-                    <meta property="twitter:url" content={seoTwitterUrl} />
-                )}
-                {!!seoTwitterImage && (
-                    <meta property="twitter:image" content={seoTwitterImage} />
-                )}
-                <meta name="robots" content={seoMetaRobots.value} />
-                {!!canonicalLink && (
-                    <link rel="canonical" href={canonicalLink} />
-                )}
-            </Head>
+            {shouldRenderSeo && (
+                <Head>
+                    <title>{seoHtmlTitle}</title>
+                    <link rel="icon" href="/favicon.ico" />
+                    {!!seoMetaDescription && (
+                        <meta name="description" content={seoMetaDescription} />
+                    )}
+                    {!!seoOgTitle && (
+                        <meta property="og:title" content={seoOgTitle} />
+                    )}
+                    {!!seoOgDescription && (
+                        <meta
+                            property="og:description"
+                            content={seoOgDescription}
+                        />
+                    )}
+                    {!!seoOgUrl && (
+                        <meta property="og:url" content={seoOgUrl} />
+                    )}
+                    {!!seoOgImage && (
+                        <meta property="og:image" content={seoOgImage} />
+                    )}
+                    {!!seoOgType && (
+                        <meta property="og:type" content={seoOgType} />
+                    )}
+                    {!!seoTwitterTitle && (
+                        <meta
+                            property="twitter:title"
+                            content={seoTwitterTitle}
+                        />
+                    )}
+                    {!!seoTwitterDescription && (
+                        <meta
+                            property="twitter:description"
+                            content={seoTwitterDescription}
+                        />
+                    )}
+                    {!!seoTwitterUrl && (
+                        <meta property="twitter:url" content={seoTwitterUrl} />
+                    )}
+                    {!!seoTwitterImage && (
+                        <meta
+                            property="twitter:image"
+                            content={seoTwitterImage}
+                        />
+                    )}
+                    <meta name="robots" content={seoMetaRobots.value} />
+                    {!!canonicalLink && (
+                        <link rel="canonical" href={canonicalLink} />
+                    )}
+                </Head>
+            )}
             <div className="BasePage">{children}</div>
             {!!wagtailUserbar && <WagtailUserbar {...wagtailUserbar} />}
         </>
@@ -71,6 +83,7 @@ const BasePage = ({ children, seo, wagtailUserbar }) => {
 
 BasePage.defaultProps = {
     seo: {},
+    shouldRenderSeo: true,
 };
 
 BasePage.propTypes = {
@@ -88,6 +101,7 @@ BasePage.propTypes = {
             value: PropTypes.string,
         }),
     }),
+    shouldRenderSeo: PropTypes.bool,
     wagtailUserbar: PropTypes.shape({
         html: PropTypes.string,
     }),

--- a/{{cookiecutter.project_name}}/frontend/containers/NotFoundPage/NotFoundPage.js
+++ b/{{cookiecutter.project_name}}/frontend/containers/NotFoundPage/NotFoundPage.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import s from './NotFoundPage.module.css';
 
-const NotFoundPage = () => {
-    return <div className={s.Container}>NotFoundPage</div>;
+const NotFoundPage = ({ exception }) => {
+    return <div className={s.Container}>{exception}</div>;
 };
 
 NotFoundPage.propTypes = {};
-
-NotFoundPage.defaultProps = {};
 
 export default NotFoundPage;

--- a/{{cookiecutter.project_name}}/frontend/containers/PasswordProtectedPage/PasswordProtectedPage.js
+++ b/{{cookiecutter.project_name}}/frontend/containers/PasswordProtectedPage/PasswordProtectedPage.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/{{cookiecutter.project_name}}/frontend/middleware.js
+++ b/{{cookiecutter.project_name}}/frontend/middleware.js
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+
+export function middleware(request) {
+    const url = new URL(request.url);
+    const origin = url.origin;
+    const pathname = url.pathname;
+    const requestHeaders = new Headers(request.headers);
+
+    requestHeaders.set('x-url', request.url);
+    requestHeaders.set('x-origin', origin);
+    requestHeaders.set('x-pathname', pathname);
+
+    return NextResponse.next({
+        request: {
+            headers: requestHeaders,
+        },
+    });
+}

--- a/{{cookiecutter.project_name}}/frontend/package.json
+++ b/{{cookiecutter.project_name}}/frontend/package.json
@@ -24,18 +24,6 @@
         "react": "^18.2.0",
         "react-dom": "18.2.0"
     },
-    "browserslist": {
-        "production": [
-            ">0.2%",
-            "not dead",
-            "not op_mini all"
-        ],
-        "development": [
-            "last 1 chrome version",
-            "last 1 firefox version",
-            "last 1 safari version"
-        ]
-    },
     "husky": {
         "hooks": {
             "pre-commit": "pretty-quick --staged --pattern 'frontend/**' && jest --onlyChanged",

--- a/{{cookiecutter.project_name}}/frontend/pages/[...path].js
+++ b/{{cookiecutter.project_name}}/frontend/pages/[...path].js
@@ -32,7 +32,7 @@ export async function getServerSideProps({ req, params, res }) {
     queryParams = {
         ...queryParams,
         host,
-    }
+    };
 
     // Try to serve page
     try {

--- a/{{cookiecutter.project_name}}/src/pipit/settings/base.py
+++ b/{{cookiecutter.project_name}}/src/pipit/settings/base.py
@@ -197,7 +197,7 @@ ADMIN_URL = "wt/admin/"
 # NextJS
 WAGTAIL_HEADLESS_PREVIEW = {
     "CLIENT_URLS": {
-        "default": "/api/preview/",
+        "default": "/api/{{ 'draft' if cookiecutter.experimental_use_app_router == 'True' else 'preview' }}/",
     }
 }
 


### PR DESCRIPTION
This is a PR that contains an implementation where we migrate from "Pages Router" to the new "App Router" (https://github.com/Frojd/Wagtail-Pipit/issues/1421).
This pull request is a work in progress and lots of work needs to be done, but this is a basic working example. Expect more updates here in the future.

## What works:
- Draft mode (https://nextjs.org/docs/app/building-your-application/configuring/draft-mode)
-  Metadata (https://nextjs.org/docs/app/building-your-application/optimizing/metadata) (https://github.com/Frojd/Wagtail-Pipit/issues/1419).
- Password protected pages in Wagtail
- Login protected pages in Wagtail
- Retrieving and setting cookies through `set-cookie` header (using a special "use client" component)
- Redirects (we cannot return headers from a page but we can return redirects use a special redirect function)
- Pass host data to the Wagtail API (we can't send `Host` headers any more using fetch, but we can pass along a query param called `host` which we use to find proper website)
- I18n, but needs more testing

## What does not work:
- Returning another content type as we cannot return headers from a page in App Router
- Set lang attribute on `<html>`
- Storybook, not implemented yet
- Jest, not implemented yet
- SSG, not implemented yet

## Current bugs:
- Currently we make duplicate page data requests as dynamic routes cannot be cached in Next.js. We need to figure out a way to cache requests. I've tried react/cache and https://nextjs.org/docs/app/api-reference/functions/unstable_cache but so far no luck. The requests are made on the page server side component, metadata fetcher and we probably need it on layout as well to be able to set html lang.

## How "App Router" is different more "Pages Router" from a Pipit perspective:
- In "Pages Router" we could load data in one place, the page route, and then pass it along to any component who needed it using clever hacks. One example of this is the `getInitialProps` function in `_document`. In "App Router" it is no longer possible as the various components (Page / Layout / Metadata) works in isolation, you are instead supposed to load data in each component and rely on Next.js caching. For us the caching does not work, due to us using a dynamic route approach, which means we want to read headers/cookies. Fetch also seems to contain some magic rules when it comes to invalidation.
- No longer possible to write headers from a page, I think it's because of React suspense. This breaks our way of setting cookies and headers, such as when we return custom types.
- We need to have a both a `page.js` and a `[...path]/page.js` to enable our way of dynamic routing. 
- Draft mode cannot store session data when previewing, the data request is expected to happen on the display side. No big deal for us, we just detect draft mode and load preview data from the API.
- Not found is no longer bound to a prop but rather a function meant to be returned from the page component
- Redirects require two different function depending on if they are temporary of permanent
- No longer possible to write meta using the <Head> component. This meant we had to drop the BaseComponent <Head> and instead use the Sitemeta API for SEO meta fields

The main issue right now is getting the page request cached correctly, this needs to be addressed for us to continue. 
Stay tuned.