### PR TITLE
Fix 'the input device is not a TTY' error in githooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 ### Fixed
+- Fix 'the input device is not a TTY' error in pre-push githook
+
 ### Removed
 
 ## [9.1.1] - 2024-07-24

--- a/{{cookiecutter.project_name}}/.githooks/pre-push.sh
+++ b/{{cookiecutter.project_name}}/.githooks/pre-push.sh
@@ -7,6 +7,6 @@
 # $1 -- Name of the remote to which the push is being done
 # $2 -- URL to which the push is being done
 
-docker-compose run python test --rm
+docker-compose run -T --rm python test
 
 exit $?


### PR DESCRIPTION
Fix issue where docker-compose crashes with 'the input device is not a TTY' in the pre-push githook