### PR TITLE
ci(fix): use docker compose v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,18 +34,18 @@ jobs:
         run: |
           cd Company-Project
           chmod +x src/docker-entrypoint.sh
-          docker-compose -f docker-compose-ci.yml build
+          docker compose -f docker-compose-ci.yml build
       - name: Verify backend scaffolder
         run: |
           cd Company-Project
           set -x
-          docker-compose -f docker-compose-ci.yml run --rm python python manage.py new_page --name=Article
+          docker compose -f docker-compose-ci.yml run --rm python python manage.py new_page --name=Article
       - name: Run tests on container
         run: |
           cd Company-Project
-          docker-compose -f docker-compose-ci.yml run --rm python test
-          docker-compose -f docker-compose-ci.yml run --rm python typecheck
-          docker-compose -f docker-compose-ci.yml run --rm python lint
+          docker compose -f docker-compose-ci.yml run --rm python test
+          docker compose -f docker-compose-ci.yml run --rm python typecheck
+          docker compose -f docker-compose-ci.yml run --rm python lint
       - name: Run frontend tests
         run: |
           cd Company-Project/frontend


### PR DESCRIPTION
Docker compose v1 `docker-compose` has been [deprecated in July 2023](https://docs.docker.com/compose/releases/migrate/), so it was quite unusual to see it supported by github actions images for this long. Yet it looks like they have finally dropped the support as well, so it is time to switch to docker compose v2 `docker compose`, with a space.
PS. Here is the link to the [GitHub annoucnment](https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/) as well.