### PR TITLE
Fix headless Wagtail userbar for logged-in editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 ### Fixed
+- Show the Wagtail userbar for logged-in editors on the headless frontend by adding DRF SessionAuthentication so the SSR page fetch authenticates, and rewrite the userbar asset host to WAGTAILADMIN_BASE_URL so vendor.js/userbar.js load from a browser-reachable host (@ottoreimers)
 ### Removed
 ### Security
 

--- a/Company-Project/docker-compose-ci.yml
+++ b/Company-Project/docker-compose-ci.yml
@@ -1,0 +1,24 @@
+services:
+  python:
+    image: frojd/wagtail_pipit_python
+    build:
+      context: ./src
+      args:
+        - ENVIRONMENT=dev
+    depends_on:
+      - db
+    env_file: ./docker/config/python.env
+
+  db:
+    image: postgis/postgis:16-3.5
+    ports:
+      - "5433:5432"
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=app
+      - POSTGRES_HOST_AUTH_METHOD=trust
+
+  frontend:
+    image: frojd/wagtail_pipit_frontend
+    build: ./frontend

--- a/Company-Project/src/main/pages/base_serializer.py
+++ b/Company-Project/src/main/pages/base_serializer.py
@@ -1,5 +1,7 @@
 from typing import List
+from urllib.parse import urlsplit
 
+from django.conf import settings
 from rest_framework import serializers
 from wagtail import fields
 from wagtail.admin.templatetags.wagtailuserbar import wagtailuserbar
@@ -54,6 +56,16 @@ class BasePageSerializer(serializers.ModelSerializer):
 
         if not hasattr(request, "user"):
             return None
+
+        # The userbar tag builds absolute asset URLs (vendor.js/userbar.js)
+        # from the request host. On the SSR fetch the reverse proxy forwards an
+        # internal Host the browser can't reach, so rewrite it to the public
+        # host from WAGTAILADMIN_BASE_URL before rendering.
+        base_url = getattr(settings, "WAGTAILADMIN_BASE_URL", None)
+        if base_url:
+            host = urlsplit(base_url).netloc
+            request.META["HTTP_HOST"] = host
+            request.META.pop("HTTP_X_FORWARDED_HOST", None)
 
         html = wagtailuserbar({"request": request, "self": page})
 

--- a/Company-Project/src/main/tests/test_base_page.py
+++ b/Company-Project/src/main/tests/test_base_page.py
@@ -85,7 +85,13 @@ class BasePageWagtailUserbarTest(WagtailPageTests):
         self.assertIsNotNone(result)
         self.assertIn("<wagtail-userbar></wagtail-userbar>", result["html"])
 
-    @override_settings(WAGTAILADMIN_BASE_URL="http://example.test:8355")
+    # The rewritten host must be in ALLOWED_HOSTS, since the userbar tag calls
+    # request.build_absolute_uri() which validates get_host(). In prod/stage
+    # WAGTAILADMIN_BASE_URL's domain is always allowlisted; mirror that here.
+    @override_settings(
+        WAGTAILADMIN_BASE_URL="http://example.test:8355",
+        ALLOWED_HOSTS=["example.test", "testserver"],
+    )
     def test_userbar_assets_use_public_host_not_internal_proxy_host(self):
         # The reverse proxy forwards the SSR fetch with an internal Host
         # (":8081") the browser can't reach, so the userbar tag would otherwise

--- a/Company-Project/src/main/tests/test_base_page.py
+++ b/Company-Project/src/main/tests/test_base_page.py
@@ -1,9 +1,15 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.test import override_settings
+from django.test.client import RequestFactory
 from rest_framework import serializers
 from wagtail.test.utils import WagtailPageTests
 from wagtail_factories import SiteFactory
 
 from main.factories.base_page import BasePageFactory
 from main.models import BasePage, BasePageSerializer
+
+User = get_user_model()
 
 
 class BasePageTest(WagtailPageTests):
@@ -39,3 +45,54 @@ class BasePageTest(WagtailPageTests):
 
         self.assertEqual(page.get_serializer_class(), BasePageSerializer)
         self.assertIn("random", page.to_dict({}, OverrideSerializer))
+
+
+class BasePageWagtailUserbarTest(WagtailPageTests):
+    """
+    The userbar is rendered server-side by the wagtailuserbar template tag,
+    which only returns markup when request.user has wagtailadmin.access_admin.
+    On the SSR page fetch, request.user is resolved by DRF SessionAuthentication
+    from the forwarded editor cookie (see REST_FRAMEWORK in settings/base.py).
+    """
+
+    def setUp(self):
+        self.root_page = BasePageFactory.create(title="Start", parent=None)
+        self.page = BasePageFactory.create(title="A page", parent=self.root_page)
+        self.request_factory = RequestFactory()
+
+    def _userbar(self, user, host=None):
+        extra = {"HTTP_HOST": host} if host else {}
+        request = self.request_factory.get("/", **extra)
+        request.user = user
+        serializer = BasePageSerializer(self.page, context={"request": request})
+        return serializer.get_wagtail_userbar(self.page)
+
+    def test_no_request_returns_none(self):
+        serializer = BasePageSerializer(self.page, context={})
+        self.assertIsNone(serializer.get_wagtail_userbar(self.page))
+
+    def test_anonymous_user_gets_no_userbar(self):
+        self.assertIsNone(self._userbar(AnonymousUser()))
+
+    def test_user_without_admin_access_gets_no_userbar(self):
+        visitor = User.objects.create_user(username="visitor", password="pw")
+        self.assertIsNone(self._userbar(visitor))
+
+    def test_editor_gets_userbar_html(self):
+        editor = User.objects.create_superuser(username="editor", password="pw")
+        result = self._userbar(editor)
+
+        self.assertIsNotNone(result)
+        self.assertIn("<wagtail-userbar></wagtail-userbar>", result["html"])
+
+    @override_settings(WAGTAILADMIN_BASE_URL="http://example.test:8355")
+    def test_userbar_assets_use_public_host_not_internal_proxy_host(self):
+        # The reverse proxy forwards the SSR fetch with an internal Host
+        # (":8081") the browser can't reach, so the userbar tag would otherwise
+        # bake that unreachable host into the vendor.js/userbar.js <script src>
+        # URLs. get_wagtail_userbar must rewrite the host to WAGTAILADMIN_BASE_URL.
+        editor = User.objects.create_superuser(username="editor", password="pw")
+        result = self._userbar(editor, host="example.test:8081")
+
+        self.assertIsNotNone(result)
+        self.assertNotIn(":8081", result["html"])

--- a/Company-Project/src/pipit/settings/base.py
+++ b/Company-Project/src/pipit/settings/base.py
@@ -169,6 +169,18 @@ WAGTAILIMAGES_FORMAT_CONVERSIONS = {
     "webp": "webp",
 }
 
+# Django REST Framework
+# The headless page data is served through DRF viewsets, which resolve
+# request.user via their own authentication classes rather than Django's
+# session middleware. SessionAuthentication lets the SSR page fetch (which
+# forwards the logged-in editor's session cookie) authenticate, so the
+# wagtailuserbar tag renders the "edit this page" bar for editors.
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "rest_framework.authentication.SessionAuthentication",
+    ),
+}
+
 # Uploaded media
 MEDIA_URL = "/wt/media/"
 MEDIA_ROOT = get_env("MEDIA_PATH", required=True)

--- a/{{cookiecutter.project_name}}/src/main/pages/base_serializer.py
+++ b/{{cookiecutter.project_name}}/src/main/pages/base_serializer.py
@@ -1,5 +1,7 @@
 from typing import List
+from urllib.parse import urlsplit
 
+from django.conf import settings
 from rest_framework import serializers
 from wagtail import fields
 from wagtail.admin.templatetags.wagtailuserbar import wagtailuserbar
@@ -54,6 +56,16 @@ class BasePageSerializer(serializers.ModelSerializer):
 
         if not hasattr(request, "user"):
             return None
+
+        # The userbar tag builds absolute asset URLs (vendor.js/userbar.js)
+        # from the request host. On the SSR fetch the reverse proxy forwards an
+        # internal Host the browser can't reach, so rewrite it to the public
+        # host from WAGTAILADMIN_BASE_URL before rendering.
+        base_url = getattr(settings, "WAGTAILADMIN_BASE_URL", None)
+        if base_url:
+            host = urlsplit(base_url).netloc
+            request.META["HTTP_HOST"] = host
+            request.META.pop("HTTP_X_FORWARDED_HOST", None)
 
         html = wagtailuserbar({"request": request, "self": page})
 

--- a/{{cookiecutter.project_name}}/src/main/tests/test_base_page.py
+++ b/{{cookiecutter.project_name}}/src/main/tests/test_base_page.py
@@ -85,7 +85,13 @@ class BasePageWagtailUserbarTest(WagtailPageTests):
         self.assertIsNotNone(result)
         self.assertIn("<wagtail-userbar></wagtail-userbar>", result["html"])
 
-    @override_settings(WAGTAILADMIN_BASE_URL="http://example.test:8355")
+    # The rewritten host must be in ALLOWED_HOSTS, since the userbar tag calls
+    # request.build_absolute_uri() which validates get_host(). In prod/stage
+    # WAGTAILADMIN_BASE_URL's domain is always allowlisted; mirror that here.
+    @override_settings(
+        WAGTAILADMIN_BASE_URL="http://example.test:8355",
+        ALLOWED_HOSTS=["example.test", "testserver"],
+    )
     def test_userbar_assets_use_public_host_not_internal_proxy_host(self):
         # The reverse proxy forwards the SSR fetch with an internal Host
         # (":8081") the browser can't reach, so the userbar tag would otherwise

--- a/{{cookiecutter.project_name}}/src/main/tests/test_base_page.py
+++ b/{{cookiecutter.project_name}}/src/main/tests/test_base_page.py
@@ -1,9 +1,15 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.test import override_settings
+from django.test.client import RequestFactory
 from rest_framework import serializers
 from wagtail.test.utils import WagtailPageTests
 from wagtail_factories import SiteFactory
 
 from main.factories.base_page import BasePageFactory
 from main.models import BasePage, BasePageSerializer
+
+User = get_user_model()
 
 
 class BasePageTest(WagtailPageTests):
@@ -39,3 +45,54 @@ class BasePageTest(WagtailPageTests):
 
         self.assertEqual(page.get_serializer_class(), BasePageSerializer)
         self.assertIn("random", page.to_dict({}, OverrideSerializer))
+
+
+class BasePageWagtailUserbarTest(WagtailPageTests):
+    """
+    The userbar is rendered server-side by the wagtailuserbar template tag,
+    which only returns markup when request.user has wagtailadmin.access_admin.
+    On the SSR page fetch, request.user is resolved by DRF SessionAuthentication
+    from the forwarded editor cookie (see REST_FRAMEWORK in settings/base.py).
+    """
+
+    def setUp(self):
+        self.root_page = BasePageFactory.create(title="Start", parent=None)
+        self.page = BasePageFactory.create(title="A page", parent=self.root_page)
+        self.request_factory = RequestFactory()
+
+    def _userbar(self, user, host=None):
+        extra = {"HTTP_HOST": host} if host else {}
+        request = self.request_factory.get("/", **extra)
+        request.user = user
+        serializer = BasePageSerializer(self.page, context={"request": request})
+        return serializer.get_wagtail_userbar(self.page)
+
+    def test_no_request_returns_none(self):
+        serializer = BasePageSerializer(self.page, context={})
+        self.assertIsNone(serializer.get_wagtail_userbar(self.page))
+
+    def test_anonymous_user_gets_no_userbar(self):
+        self.assertIsNone(self._userbar(AnonymousUser()))
+
+    def test_user_without_admin_access_gets_no_userbar(self):
+        visitor = User.objects.create_user(username="visitor", password="pw")
+        self.assertIsNone(self._userbar(visitor))
+
+    def test_editor_gets_userbar_html(self):
+        editor = User.objects.create_superuser(username="editor", password="pw")
+        result = self._userbar(editor)
+
+        self.assertIsNotNone(result)
+        self.assertIn("<wagtail-userbar></wagtail-userbar>", result["html"])
+
+    @override_settings(WAGTAILADMIN_BASE_URL="http://example.test:8355")
+    def test_userbar_assets_use_public_host_not_internal_proxy_host(self):
+        # The reverse proxy forwards the SSR fetch with an internal Host
+        # (":8081") the browser can't reach, so the userbar tag would otherwise
+        # bake that unreachable host into the vendor.js/userbar.js <script src>
+        # URLs. get_wagtail_userbar must rewrite the host to WAGTAILADMIN_BASE_URL.
+        editor = User.objects.create_superuser(username="editor", password="pw")
+        result = self._userbar(editor, host="example.test:8081")
+
+        self.assertIsNotNone(result)
+        self.assertNotIn(":8081", result["html"])

--- a/{{cookiecutter.project_name}}/src/pipit/settings/base.py
+++ b/{{cookiecutter.project_name}}/src/pipit/settings/base.py
@@ -169,6 +169,18 @@ WAGTAILIMAGES_FORMAT_CONVERSIONS = {
     "webp": "webp",
 }
 
+# Django REST Framework
+# The headless page data is served through DRF viewsets, which resolve
+# request.user via their own authentication classes rather than Django's
+# session middleware. SessionAuthentication lets the SSR page fetch (which
+# forwards the logged-in editor's session cookie) authenticate, so the
+# wagtailuserbar tag renders the "edit this page" bar for editors.
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "rest_framework.authentication.SessionAuthentication",
+    ),
+}
+
 # Uploaded media
 MEDIA_URL = "/wt/media/"
 MEDIA_ROOT = get_env("MEDIA_PATH", required=True)


### PR DESCRIPTION
## Problem

The Wagtail userbar ("edit this page" / the bird trigger) does not work on the
headless frontend for logged-in editors. Two independent root causes:

### 1. Userbar never renders (missing DRF SessionAuthentication)

SSR page data is served through DRF viewsets (`PageByPathAPIViewSet`), which
resolve `request.user` via their own `DEFAULT_AUTHENTICATION_CLASSES` — not
Django's session middleware. With no `REST_FRAMEWORK` config, the editor's
forwarded session cookie is ignored, `request.user` is anonymous, and
`wagtailuserbar` returns an empty string.

Fix: add `SessionAuthentication` to `REST_FRAMEWORK` in `settings/base.py`.

### 2. Userbar renders but its JS fails to load (internal host baked into asset URLs)

The `wagtailuserbar` tag builds absolute asset URLs (`vendor.js` / `userbar.js`)
from the request host. On the SSR fetch, the reverse proxy forwards an internal
`Host` (the docker web port), so those URLs point at a host the browser can't
reach → `ERR_CONNECTION_REFUSED`.

Fix: `get_wagtail_userbar` rewrites the request host to `WAGTAILADMIN_BASE_URL`
before rendering (no-op if that setting is unset).

## Changes

- `settings/base.py`: add `REST_FRAMEWORK` with `SessionAuthentication`
- `main/pages/base_serializer.py`: rewrite userbar asset host to `WAGTAILADMIN_BASE_URL`
- `main/tests/test_base_page.py`: add `BasePageWagtailUserbarTest` (anonymous / non-admin → no bar, editor → bar, and asset host is public not internal)
- `CHANGELOG.md`: entry under Unreleased → Fixed
- `Company-Project/`: regenerated to match

## Testing

Rendered a fresh project from the template via cookiecutter and ran the suite:
**34 passed**, including the 5 new userbar tests and the full `nextjs/` API suite.
The password-protected page API tests still pass — `SessionAuthentication` only
enforces CSRF on session-authenticated requests, so anonymous public POSTs are
unaffected.

Also verified live on a real headless project: userbar assets now load 200 and
the userbar renders for editors.